### PR TITLE
[Hotfix] Restore missing migration versions for shared-staging

### DIFF
--- a/migrations/20260220193000_web_owner_dashboard_notifications.sql
+++ b/migrations/20260220193000_web_owner_dashboard_notifications.sql
@@ -1,0 +1,375 @@
+-- owner dashboard + notifications
+-- - add payment ledger for reservation deposit/balance tracking
+-- - add owner notification inbox + read states
+-- - add automatic notification triggers (reservation/quote/payment)
+
+create table if not exists public.reservation_payment_ledgers (
+  id uuid primary key default gen_random_uuid(),
+  reservation_id uuid not null references public.reservations(id) on delete cascade,
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  payment_stage text not null,
+  amount integer not null,
+  paid_at timestamp with time zone not null default now(),
+  memo text not null default '',
+  recorded_by uuid not null references auth.users(id) on delete restrict,
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint reservation_payment_ledgers_stage_check
+    check (payment_stage in ('DEPOSIT', 'BALANCE')),
+  constraint reservation_payment_ledgers_amount_check
+    check (amount >= 0),
+  constraint reservation_payment_ledgers_memo_len_check
+    check (char_length(memo) <= 1000),
+  constraint reservation_payment_ledgers_unique
+    unique (reservation_id, payment_stage)
+);
+
+create index if not exists reservation_payment_ledgers_shop_paid_idx
+  on public.reservation_payment_ledgers (shop_id, paid_at desc);
+
+create index if not exists reservation_payment_ledgers_reservation_paid_idx
+  on public.reservation_payment_ledgers (reservation_id, paid_at desc);
+
+create or replace function public.reservation_payment_ledgers_fill_shop_id()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_shop_id uuid;
+begin
+  select r.shop_id
+    into v_shop_id
+  from public.reservations r
+  where r.id = new.reservation_id;
+
+  if v_shop_id is null then
+    raise exception 'reservation not found for ledger.reservation_id=%', new.reservation_id;
+  end if;
+
+  new.shop_id := v_shop_id;
+  return new;
+end;
+$$;
+
+drop trigger if exists reservation_payment_ledgers_fill_shop_id_trg on public.reservation_payment_ledgers;
+create trigger reservation_payment_ledgers_fill_shop_id_trg
+before insert or update of reservation_id
+on public.reservation_payment_ledgers
+for each row execute function public.reservation_payment_ledgers_fill_shop_id();
+
+drop trigger if exists set_reservation_payment_ledgers_updated_at on public.reservation_payment_ledgers;
+create trigger set_reservation_payment_ledgers_updated_at
+before update on public.reservation_payment_ledgers
+for each row execute function public.set_updated_at();
+
+alter table public.reservation_payment_ledgers enable row level security;
+
+drop policy if exists reservation_payment_ledgers_select_by_user on public.reservation_payment_ledgers;
+create policy reservation_payment_ledgers_select_by_user
+on public.reservation_payment_ledgers
+for select
+using (
+  exists (
+    select 1
+    from public.reservations r
+    where r.id = reservation_payment_ledgers.reservation_id
+      and r.user_id = auth.uid()
+  )
+  or exists (
+    select 1
+    from public.shop_members sm
+    where sm.shop_id = reservation_payment_ledgers.shop_id
+      and sm.user_id = auth.uid()
+  )
+);
+
+drop policy if exists reservation_payment_ledgers_insert_by_shop_membership on public.reservation_payment_ledgers;
+create policy reservation_payment_ledgers_insert_by_shop_membership
+on public.reservation_payment_ledgers
+for insert
+with check (
+  recorded_by = auth.uid()
+  and exists (
+    select 1
+    from public.shop_members sm
+    where sm.shop_id = reservation_payment_ledgers.shop_id
+      and sm.user_id = auth.uid()
+  )
+);
+
+drop policy if exists reservation_payment_ledgers_update_by_shop_membership on public.reservation_payment_ledgers;
+create policy reservation_payment_ledgers_update_by_shop_membership
+on public.reservation_payment_ledgers
+for update
+using (
+  exists (
+    select 1
+    from public.shop_members sm
+    where sm.shop_id = reservation_payment_ledgers.shop_id
+      and sm.user_id = auth.uid()
+  )
+)
+with check (
+  recorded_by = auth.uid()
+  and exists (
+    select 1
+    from public.shop_members sm
+    where sm.shop_id = reservation_payment_ledgers.shop_id
+      and sm.user_id = auth.uid()
+  )
+);
+
+create table if not exists public.owner_notifications (
+  id uuid primary key default gen_random_uuid(),
+  shop_id uuid not null references public.shops(id) on delete cascade,
+  type text not null,
+  title text not null,
+  description text not null,
+  source_table text not null,
+  source_id uuid not null,
+  source_event text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamp with time zone not null default now(),
+  constraint owner_notifications_type_check
+    check (type in ('BOOKING_CREATED', 'QUOTE_REQUEST_CREATED', 'PAYMENT_RECORDED', 'SYSTEM')),
+  constraint owner_notifications_title_len_check
+    check (char_length(title) <= 120),
+  constraint owner_notifications_description_len_check
+    check (char_length(description) <= 500),
+  constraint owner_notifications_source_unique
+    unique (shop_id, source_table, source_id, source_event)
+);
+
+create index if not exists owner_notifications_shop_created_idx
+  on public.owner_notifications (shop_id, created_at desc);
+
+alter table public.owner_notifications enable row level security;
+
+drop policy if exists owner_notifications_select_by_shop_membership on public.owner_notifications;
+create policy owner_notifications_select_by_shop_membership
+on public.owner_notifications
+for select
+using (
+  exists (
+    select 1
+    from public.shop_members sm
+    where sm.shop_id = owner_notifications.shop_id
+      and sm.user_id = auth.uid()
+  )
+);
+
+create table if not exists public.owner_notification_reads (
+  id uuid primary key default gen_random_uuid(),
+  notification_id uuid not null references public.owner_notifications(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  read_at timestamp with time zone not null default now(),
+  created_at timestamp with time zone not null default now(),
+  updated_at timestamp with time zone not null default now(),
+  constraint owner_notification_reads_unique
+    unique (notification_id, user_id)
+);
+
+create index if not exists owner_notification_reads_user_read_at_idx
+  on public.owner_notification_reads (user_id, read_at desc);
+
+drop trigger if exists set_owner_notification_reads_updated_at on public.owner_notification_reads;
+create trigger set_owner_notification_reads_updated_at
+before update on public.owner_notification_reads
+for each row execute function public.set_updated_at();
+
+alter table public.owner_notification_reads enable row level security;
+
+drop policy if exists owner_notification_reads_select_own on public.owner_notification_reads;
+create policy owner_notification_reads_select_own
+on public.owner_notification_reads
+for select
+using (
+  user_id = auth.uid()
+  and exists (
+    select 1
+    from public.owner_notifications n
+    join public.shop_members sm on sm.shop_id = n.shop_id
+    where n.id = owner_notification_reads.notification_id
+      and sm.user_id = auth.uid()
+  )
+);
+
+drop policy if exists owner_notification_reads_insert_own on public.owner_notification_reads;
+create policy owner_notification_reads_insert_own
+on public.owner_notification_reads
+for insert
+with check (
+  user_id = auth.uid()
+  and exists (
+    select 1
+    from public.owner_notifications n
+    join public.shop_members sm on sm.shop_id = n.shop_id
+    where n.id = owner_notification_reads.notification_id
+      and sm.user_id = auth.uid()
+  )
+);
+
+drop policy if exists owner_notification_reads_update_own on public.owner_notification_reads;
+create policy owner_notification_reads_update_own
+on public.owner_notification_reads
+for update
+using (
+  user_id = auth.uid()
+)
+with check (
+  user_id = auth.uid()
+);
+
+create or replace function public.owner_notifications_on_reservation_created()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_customer text;
+  v_service text;
+  v_description text;
+begin
+  select coalesce(u.nickname, '고객 ' || left(new.user_id::text, 8)),
+         coalesce(r.title, '시술')
+    into v_customer, v_service
+  from public.users u
+  left join public.references r on r.id = new.reference_id
+  where u.id = new.user_id;
+
+  v_description := format('%s님이 %s 예약을 생성했습니다.', v_customer, v_service);
+
+  insert into public.owner_notifications (
+    shop_id,
+    type,
+    title,
+    description,
+    source_table,
+    source_id,
+    source_event,
+    metadata
+  ) values (
+    new.shop_id,
+    'BOOKING_CREATED',
+    '새 예약 접수',
+    v_description,
+    'reservations',
+    new.id,
+    'CREATED',
+    jsonb_build_object('reservation_status', new.status)
+  )
+  on conflict (shop_id, source_table, source_id, source_event) do nothing;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists owner_notifications_on_reservation_created_trg on public.reservations;
+create trigger owner_notifications_on_reservation_created_trg
+after insert on public.reservations
+for each row execute function public.owner_notifications_on_reservation_created();
+
+create or replace function public.owner_notifications_on_quote_target_created()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_customer text;
+  v_note text;
+  v_description text;
+begin
+  select coalesce(u.nickname, '고객 ' || left(qr.user_id::text, 8)),
+         coalesce(nullif(trim(qr.request_note), ''), '요청 메모 없음')
+    into v_customer, v_note
+  from public.quote_requests qr
+  left join public.users u on u.id = qr.user_id
+  where qr.id = new.quote_request_id;
+
+  v_description := format('%s님의 요청서가 도착했습니다. %s', v_customer, left(v_note, 120));
+
+  insert into public.owner_notifications (
+    shop_id,
+    type,
+    title,
+    description,
+    source_table,
+    source_id,
+    source_event,
+    metadata
+  ) values (
+    new.shop_id,
+    'QUOTE_REQUEST_CREATED',
+    '새 견적 요청서 도착',
+    v_description,
+    'quote_request_targets',
+    new.id,
+    'CREATED',
+    jsonb_build_object('target_status', new.status)
+  )
+  on conflict (shop_id, source_table, source_id, source_event) do nothing;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists owner_notifications_on_quote_target_created_trg on public.quote_request_targets;
+create trigger owner_notifications_on_quote_target_created_trg
+after insert on public.quote_request_targets
+for each row execute function public.owner_notifications_on_quote_target_created();
+
+create or replace function public.owner_notifications_on_payment_recorded()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_title text;
+  v_description text;
+begin
+  v_title := case new.payment_stage
+    when 'DEPOSIT' then '예약금 결제 기록'
+    when 'BALANCE' then '잔금 결제 기록'
+    else '결제 기록'
+  end;
+
+  v_description := format('%s %s원이 기록되었습니다.', v_title, to_char(new.amount, 'FM999,999,999,990'));
+
+  insert into public.owner_notifications (
+    shop_id,
+    type,
+    title,
+    description,
+    source_table,
+    source_id,
+    source_event,
+    metadata
+  ) values (
+    new.shop_id,
+    'PAYMENT_RECORDED',
+    v_title,
+    v_description,
+    'reservation_payment_ledgers',
+    new.id,
+    new.payment_stage,
+    jsonb_build_object(
+      'reservation_id', new.reservation_id,
+      'payment_stage', new.payment_stage,
+      'amount', new.amount
+    )
+  )
+  on conflict (shop_id, source_table, source_id, source_event) do nothing;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists owner_notifications_on_payment_recorded_trg on public.reservation_payment_ledgers;
+create trigger owner_notifications_on_payment_recorded_trg
+after insert on public.reservation_payment_ledgers
+for each row execute function public.owner_notifications_on_payment_recorded();

--- a/migrations/20260220200000_web_options_select_owner_account_settings.sql
+++ b/migrations/20260220200000_web_options_select_owner_account_settings.sql
@@ -1,0 +1,79 @@
+-- Extend options type to include SELECT and add owner account settings.
+
+alter table if exists public.options
+  drop constraint if exists options_type_check;
+
+alter table if exists public.options
+  add constraint options_type_check
+  check (type = any (array['ADDON'::text, 'QUANTITY'::text, 'SELECT'::text])) not valid;
+
+alter table if exists public.options
+  validate constraint options_type_check;
+
+create table if not exists public.owner_account_settings (
+  user_id uuid primary key references public.users(id) on delete cascade,
+  notify_system_notice boolean not null default true,
+  notify_security_notice boolean not null default true,
+  notify_marketing boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+drop trigger if exists set_owner_account_settings_updated_at on public.owner_account_settings;
+create trigger set_owner_account_settings_updated_at
+before update on public.owner_account_settings
+for each row execute function public.set_updated_at();
+
+alter table public.owner_account_settings enable row level security;
+
+drop policy if exists owner_account_settings_select_self on public.owner_account_settings;
+create policy owner_account_settings_select_self
+on public.owner_account_settings
+for select
+using (auth.uid() = user_id);
+
+drop policy if exists owner_account_settings_insert_self on public.owner_account_settings;
+create policy owner_account_settings_insert_self
+on public.owner_account_settings
+for insert
+with check (auth.uid() = user_id);
+
+drop policy if exists owner_account_settings_update_self on public.owner_account_settings;
+create policy owner_account_settings_update_self
+on public.owner_account_settings
+for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+drop policy if exists owner_account_settings_delete_self on public.owner_account_settings;
+create policy owner_account_settings_delete_self
+on public.owner_account_settings
+for delete
+using (auth.uid() = user_id);
+
+do $$
+declare
+  quote_targets_reg regclass := to_regclass('public.quote_request_targets');
+  quote_responses_reg regclass := to_regclass('public.quote_responses');
+  publication_exists boolean := exists (
+    select 1 from pg_publication where pubname = 'supabase_realtime'
+  );
+begin
+  if publication_exists and quote_targets_reg is not null and not exists (
+    select 1
+    from pg_publication_rel
+    where prpubid = (select oid from pg_publication where pubname = 'supabase_realtime')
+      and prrelid = quote_targets_reg
+  ) then
+    execute 'alter publication supabase_realtime add table public.quote_request_targets';
+  end if;
+
+  if publication_exists and quote_responses_reg is not null and not exists (
+    select 1
+    from pg_publication_rel
+    where prpubid = (select oid from pg_publication where pubname = 'supabase_realtime')
+      and prrelid = quote_responses_reg
+  ) then
+    execute 'alter publication supabase_realtime add table public.quote_responses';
+  end if;
+end $$;

--- a/migrations/20260221100000_ios_user_default_region_and_region_boundaries.sql
+++ b/migrations/20260221100000_ios_user_default_region_and_region_boundaries.sql
@@ -1,0 +1,92 @@
+-- User default region + region boundary cache tables for region picker UX.
+
+alter table public.users
+  add column if not exists default_region_id uuid;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'users_default_region_id_fkey'
+      and conrelid = 'public.users'::regclass
+  ) then
+    alter table public.users
+      add constraint users_default_region_id_fkey
+      foreign key (default_region_id) references public.regions(id)
+      on delete set null;
+  end if;
+end
+$$;
+
+create index if not exists users_default_region_id_idx
+  on public.users (default_region_id);
+
+create table if not exists public.region_boundaries (
+  region_id uuid primary key references public.regions(id) on delete cascade,
+  geometry jsonb not null,
+  bbox jsonb not null,
+  center jsonb not null,
+  source text not null default 'vworld',
+  source_version text not null,
+  synced_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.region_sync_meta (
+  source_version text primary key,
+  synced_at timestamptz not null,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.region_boundaries enable row level security;
+alter table public.region_sync_meta enable row level security;
+
+drop policy if exists public_read_region_boundaries on public.region_boundaries;
+create policy public_read_region_boundaries
+on public.region_boundaries
+for select
+to authenticated
+using (true);
+
+drop policy if exists service_manage_region_boundaries on public.region_boundaries;
+create policy service_manage_region_boundaries
+on public.region_boundaries
+for all
+to service_role
+using (true)
+with check (true);
+
+drop policy if exists public_read_region_sync_meta on public.region_sync_meta;
+create policy public_read_region_sync_meta
+on public.region_sync_meta
+for select
+to authenticated
+using (true);
+
+drop policy if exists service_manage_region_sync_meta on public.region_sync_meta;
+create policy service_manage_region_sync_meta
+on public.region_sync_meta
+for all
+to service_role
+using (true)
+with check (true);
+
+drop trigger if exists set_region_boundaries_updated_at on public.region_boundaries;
+create trigger set_region_boundaries_updated_at
+before update on public.region_boundaries
+for each row execute function public.set_updated_at();
+
+drop trigger if exists set_region_sync_meta_updated_at on public.region_sync_meta;
+create trigger set_region_sync_meta_updated_at
+before update on public.region_sync_meta
+for each row execute function public.set_updated_at();
+
+grant select on table public.region_boundaries to authenticated;
+grant all on table public.region_boundaries to service_role;
+
+grant select on table public.region_sync_meta to authenticated;
+grant all on table public.region_sync_meta to service_role;

--- a/migrations/20260221113000_ios_google_social_identity.sql
+++ b/migrations/20260221113000_ios_google_social_identity.sql
@@ -1,0 +1,53 @@
+-- Multi-social identity table for Kakao + Google login
+-- Keep users.kakao_user_id for backward compatibility, but move source of truth to user_identities.
+
+create table if not exists public.user_identities (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.users(id) on delete cascade,
+  provider text not null,
+  provider_user_id text not null,
+  email text,
+  email_verified boolean not null default false,
+  display_name text,
+  profile_image_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  last_login_at timestamptz not null default now(),
+  constraint user_identities_provider_check check (provider in ('kakao', 'google'))
+);
+
+create unique index if not exists user_identities_provider_provider_user_id_key
+  on public.user_identities (provider, provider_user_id);
+
+create unique index if not exists user_identities_user_provider_key
+  on public.user_identities (user_id, provider);
+
+create index if not exists user_identities_user_id_idx
+  on public.user_identities (user_id);
+
+alter table if exists public.user_identities enable row level security;
+
+alter table if exists public.users
+  alter column kakao_user_id drop not null;
+
+insert into public.user_identities (
+  user_id,
+  provider,
+  provider_user_id,
+  email_verified,
+  last_login_at
+)
+select
+  u.id,
+  'kakao',
+  u.kakao_user_id,
+  false,
+  now()
+from public.users u
+where coalesce(trim(u.kakao_user_id), '') <> ''
+on conflict (provider, provider_user_id)
+do update
+set
+  user_id = excluded.user_id,
+  updated_at = now(),
+  last_login_at = excluded.last_login_at;

--- a/migrations/20260221120000_ios_nail_generation_likes.sql
+++ b/migrations/20260221120000_ios_nail_generation_likes.sql
@@ -1,0 +1,14 @@
+create table if not exists public.nail_generation_likes (
+  user_id uuid not null references public.users(id) on delete cascade,
+  job_id uuid not null references public.nail_generation_jobs(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  constraint nail_generation_likes_pkey primary key (user_id, job_id)
+);
+
+create index if not exists nail_generation_likes_user_created_job_desc_idx
+  on public.nail_generation_likes (user_id, created_at desc, job_id desc);
+
+create index if not exists nail_generation_likes_job_idx
+  on public.nail_generation_likes (job_id);
+
+alter table public.nail_generation_likes enable row level security;

--- a/migrations/20260221140000_ios_nail_generation_jobs_soft_delete.sql
+++ b/migrations/20260221140000_ios_nail_generation_jobs_soft_delete.sql
@@ -1,0 +1,6 @@
+alter table public.nail_generation_jobs
+  add column if not exists deleted_at timestamptz;
+
+create index if not exists nail_generation_jobs_active_user_created_idx
+  on public.nail_generation_jobs (user_id, created_at desc)
+  where deleted_at is null;

--- a/migrations/20260221150000_ios_user_identities_add_apple.sql
+++ b/migrations/20260221150000_ios_user_identities_add_apple.sql
@@ -1,0 +1,16 @@
+-- Extend provider check constraint for Apple social login support.
+
+do $$
+begin
+  if to_regclass('public.user_identities') is null then
+    return;
+  end if;
+
+  alter table public.user_identities
+    drop constraint if exists user_identities_provider_check;
+
+  alter table public.user_identities
+    add constraint user_identities_provider_check
+    check (provider in ('kakao', 'google', 'apple'));
+end
+$$;

--- a/migrations/20260221151000_ios_social_login_ui_variant_flag.sql
+++ b/migrations/20260221151000_ios_social_login_ui_variant_flag.sql
@@ -1,0 +1,28 @@
+-- Runtime UI switch for social login buttons.
+-- Default is circular icon UI, with server-side rollback to official wide buttons.
+
+create table if not exists public.app_runtime_flags (
+  key text primary key,
+  value text not null,
+  updated_at timestamptz not null default now(),
+  constraint app_runtime_flags_key_check
+    check (key in ('social_login_ui_variant')),
+  constraint app_runtime_flags_value_check
+    check (
+      key <> 'social_login_ui_variant'
+      or value in ('circular', 'official')
+    )
+);
+
+drop trigger if exists set_app_runtime_flags_updated_at on public.app_runtime_flags;
+create trigger set_app_runtime_flags_updated_at
+before update on public.app_runtime_flags
+for each row execute function public.set_updated_at();
+
+alter table public.app_runtime_flags enable row level security;
+
+insert into public.app_runtime_flags (key, value)
+values ('social_login_ui_variant', 'circular')
+on conflict (key) do update
+set value = excluded.value,
+    updated_at = now();

--- a/migrations/20260221170000_ios_onboarding_style_assets.sql
+++ b/migrations/20260221170000_ios_onboarding_style_assets.sql
@@ -1,0 +1,46 @@
+-- Onboarding preferred style image metadata
+-- - Image binary lives in public storage bucket.
+-- - DB table stores style key -> public image URL mapping.
+
+insert into storage.buckets (id, name, public)
+values ('onboarding-style-images-public', 'onboarding-style-images-public', true)
+on conflict (id) do update
+set name = excluded.name,
+    public = excluded.public;
+
+create table if not exists public.onboarding_style_assets (
+  style_key text primary key,
+  image_url text not null,
+  updated_at timestamptz not null default now(),
+  constraint onboarding_style_assets_style_key_check check (
+    style_key in (
+      'office_minimal',
+      'natural',
+      'lovely',
+      'hip',
+      'chic_modern',
+      'kitsh_unique',
+      'glitter_pearl',
+      'french',
+      'gradient_ombre',
+      'wedding',
+      'season_spring',
+      'point-art'
+    )
+  ),
+  constraint onboarding_style_assets_image_url_non_empty check (char_length(btrim(image_url)) > 0)
+);
+
+alter table public.onboarding_style_assets enable row level security;
+
+drop policy if exists onboarding_style_assets_select_public on public.onboarding_style_assets;
+create policy onboarding_style_assets_select_public
+on public.onboarding_style_assets
+for select
+to anon, authenticated
+using (true);
+
+drop trigger if exists trg_onboarding_style_assets_updated_at on public.onboarding_style_assets;
+create trigger trg_onboarding_style_assets_updated_at
+before update on public.onboarding_style_assets
+for each row execute function public.set_updated_at();

--- a/migrations/20260221180000_ios_nail_generation_extension_mode.sql
+++ b/migrations/20260221180000_ios_nail_generation_extension_mode.sql
@@ -1,0 +1,24 @@
+-- Move nail extension option to a structured column.
+
+alter table if exists public.nail_generation_jobs
+  add column if not exists extension_mode text;
+
+update public.nail_generation_jobs
+set extension_mode = case
+  when upper(trim(coalesce(user_prompt, ''))) = 'EXT_MODE=EXTEND' then 'EXTEND'
+  else 'NATURAL'
+end
+where extension_mode is null;
+
+alter table if exists public.nail_generation_jobs
+  alter column extension_mode set default 'NATURAL';
+
+alter table if exists public.nail_generation_jobs
+  alter column extension_mode set not null;
+
+alter table if exists public.nail_generation_jobs
+  drop constraint if exists nail_generation_jobs_extension_mode_check;
+
+alter table if exists public.nail_generation_jobs
+  add constraint nail_generation_jobs_extension_mode_check
+  check (extension_mode in ('NATURAL', 'EXTEND'));

--- a/migrations/20260221210000_ios_nail_generation_result_thumbnail.sql
+++ b/migrations/20260221210000_ios_nail_generation_result_thumbnail.sql
@@ -1,0 +1,11 @@
+begin;
+
+alter table if exists public.nail_generation_jobs
+  add column if not exists result_thumbnail_object_path text;
+
+insert into storage.buckets (id, name, public)
+values ('nail-results-thumb-public', 'nail-results-thumb-public', true)
+on conflict (id) do update
+set public = excluded.public;
+
+commit;


### PR DESCRIPTION
## 배경/문제
- `Apply Shared Staging` run `22704775328`가 `supabase db push` 단계에서 실패했습니다.
- 오류: `Remote migration versions not found in local migrations directory.`
- 원인: 원격 DB에 기록된 migration 버전 11개가 `shared-schema/migrations`에 누락됨.

## 변경 내용
- `client-app-ios` 삭제 직전 커밋(`90d0fb1`)의 원본 SQL을 기준으로 누락된 11개 migration 파일을 복원했습니다.
- `migration repair`는 사용하지 않고 canonical 저장소의 파일 이력을 복구했습니다.

## 복원 파일
- `20260220193000_web_owner_dashboard_notifications.sql`
- `20260220200000_web_options_select_owner_account_settings.sql`
- `20260221100000_ios_user_default_region_and_region_boundaries.sql`
- `20260221113000_ios_google_social_identity.sql`
- `20260221120000_ios_nail_generation_likes.sql`
- `20260221140000_ios_nail_generation_jobs_soft_delete.sql`
- `20260221150000_ios_user_identities_add_apple.sql`
- `20260221151000_ios_social_login_ui_variant_flag.sql`
- `20260221170000_ios_onboarding_style_assets.sql`
- `20260221180000_ios_nail_generation_extension_mode.sql`
- `20260221210000_ios_nail_generation_result_thumbnail.sql`

## 검증
- `bash scripts/check-migration-names.sh` 통과
- 로컬 `supabase migration list` 검증은 Supabase CLI 부재로 수행 불가(에러: `command not found: supabase`)
- 최종 검증은 머지 후 Actions 재실행 성공 여부로 확인

## 리스크/롤백
- 리스크: 낮음 (원격에 이미 적용된 버전의 이력 파일 복원)
- 롤백: squash merge commit revert
