### PR TITLE
fix(thumbnails): JPEG 썸네일 저장 통일과 기존 결과 썸네일 백필

### DIFF
--- a/scripts/backfill-nail-result-thumbnails.ts
+++ b/scripts/backfill-nail-result-thumbnails.ts
@@ -1,0 +1,201 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.95.3";
+import pg from "npm:pg";
+import {
+  buildJpegThumbnailBytesFromResult,
+  defaultThumbnailObjectPath,
+  THUMBNAIL_BUCKET,
+  THUMBNAIL_CONTENT_TYPE,
+  updateThumbnailPath,
+  uploadJpegThumbnail,
+} from "../supabase/functions/_shared/nail-result-thumbnails.ts";
+import { requireEnv } from "../supabase/functions/_shared/env.ts";
+
+type JobRow = {
+  id: string;
+  user_id: string;
+  created_at: string;
+  result_object_path: string | null;
+  result_thumbnail_object_path: string | null;
+};
+
+type StorageObjectRow = {
+  name: string;
+  mimetype: string | null;
+};
+
+const supabaseUrl = requireEnv("SUPABASE_URL");
+const dbUrl = requireEnv("SUPABASE_DB_URL");
+const serviceRoleKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+const db = new pg.Client({ connectionString: dbUrl });
+
+type Options = {
+  dryRun: boolean;
+  limit: number;
+  afterId: string | null;
+};
+
+function parseArgs(args: string[]): Options {
+  let dryRun = false;
+  let limit = 50;
+  let afterId: string | null = null;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--limit") {
+      const value = Number(args[i + 1]);
+      if (!Number.isInteger(value) || value < 1 || value > 500) {
+        throw new Error("--limit must be an integer between 1 and 500");
+      }
+      limit = value;
+      i += 1;
+      continue;
+    }
+    if (arg === "--after-id") {
+      const value = args[i + 1]?.trim();
+      if (!value) {
+        throw new Error("--after-id requires a job id");
+      }
+      afterId = value.toLowerCase();
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { dryRun, limit, afterId };
+}
+
+async function resolveAnchor(afterId: string): Promise<{ created_at: string; id: string }> {
+  const result = await db.query<{ id: string; created_at: string }>(
+    "select id::text as id, created_at::text as created_at from public.nail_generation_jobs where id = $1 limit 1",
+    [afterId],
+  );
+  const data = result.rows[0];
+  if (!data) {
+    throw new Error(`anchor job not found: ${afterId}`);
+  }
+
+  return {
+    created_at: new Date(data.created_at).toISOString(),
+    id: data.id.toLowerCase(),
+  };
+}
+
+async function fetchScanBatch(limit: number, afterId: string | null): Promise<JobRow[]> {
+  const values: (string | number)[] = [];
+  let sql = `
+    select
+      id::text as id,
+      user_id::text as user_id,
+      created_at::text as created_at,
+      result_object_path,
+      result_thumbnail_object_path
+    from public.nail_generation_jobs
+    where status = 'completed'
+      and deleted_at is null
+      and result_object_path is not null
+  `;
+  if (afterId) {
+    const anchor = await resolveAnchor(afterId);
+    values.push(anchor.created_at, anchor.id);
+    sql += `
+      and (
+        created_at < $${values.length - 1}
+        or (created_at = $${values.length - 1} and id::text < $${values.length})
+      )
+    `;
+  }
+  values.push(limit);
+  sql += `
+    order by created_at desc, id desc
+    limit $${values.length}
+  `;
+
+  const result = await db.query<JobRow>(sql, values);
+  return result.rows;
+}
+
+async function loadThumbnailMetadata(paths: string[]): Promise<Map<string, StorageObjectRow>> {
+  if (paths.length === 0) return new Map();
+
+  const result = await db.query<StorageObjectRow>(
+    `
+      select
+        name,
+        metadata->>'mimetype' as mimetype
+      from storage.objects
+      where bucket_id = $1
+        and name = any($2::text[])
+    `,
+    [THUMBNAIL_BUCKET, paths],
+  );
+
+  return new Map(result.rows.map((row: StorageObjectRow) => [row.name, row]));
+}
+
+function needsRegeneration(job: JobRow, objectRow: StorageObjectRow | undefined): boolean {
+  if (!job.result_thumbnail_object_path) return true;
+  if (!objectRow) return true;
+  return objectRow.mimetype !== THUMBNAIL_CONTENT_TYPE;
+}
+
+async function regenerateThumbnail(job: JobRow): Promise<void> {
+  const thumbnailObjectPath = job.result_thumbnail_object_path ?? defaultThumbnailObjectPath(job.user_id, job.id);
+  const thumbnailBytes = await buildJpegThumbnailBytesFromResult(job.result_object_path!);
+  await uploadJpegThumbnail(thumbnailObjectPath, thumbnailBytes);
+  await updateThumbnailPath(job.id, thumbnailObjectPath);
+}
+
+const options = parseArgs(Deno.args);
+await db.connect();
+try {
+  const scanned = await fetchScanBatch(options.limit, options.afterId);
+  const thumbnailPaths = scanned
+    .map((row) => row.result_thumbnail_object_path)
+    .filter((value): value is string => Boolean(value));
+  const metadataByPath = await loadThumbnailMetadata(thumbnailPaths);
+
+  let regeneratedCount = 0;
+  let skippedCount = 0;
+  let failedCount = 0;
+  const targetJobs = scanned.filter((job) => {
+    const objectRow = job.result_thumbnail_object_path
+      ? metadataByPath.get(job.result_thumbnail_object_path)
+      : undefined;
+    return needsRegeneration(job, objectRow);
+  });
+
+  for (const job of targetJobs) {
+    try {
+      if (!options.dryRun) {
+        await regenerateThumbnail(job);
+      }
+      regeneratedCount += 1;
+    } catch (error) {
+      failedCount += 1;
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[backfill-nail-result-thumbnails] job=${job.id} failed message=${message}`);
+    }
+  }
+
+  skippedCount = scanned.length - targetJobs.length;
+  const lastProcessedJobId = scanned.length > 0 ? scanned[scanned.length - 1].id : null;
+
+  console.log(JSON.stringify({
+    scanned_count: scanned.length,
+    regenerated_count: regeneratedCount,
+    skipped_count: skippedCount,
+    failed_count: failedCount,
+    last_processed_job_id: lastProcessedJobId,
+    dry_run: options.dryRun,
+  }, null, 2));
+} finally {
+  await db.end();
+}

--- a/supabase/functions/_shared/nail-result-thumbnails.ts
+++ b/supabase/functions/_shared/nail-result-thumbnails.ts
@@ -1,0 +1,90 @@
+import { requireEnv } from "./env.ts";
+import { supabaseAdmin } from "./supabase.ts";
+
+export const RESULT_BUCKET = "nail-results-private";
+export const THUMBNAIL_BUCKET = "nail-results-thumb-public";
+export const THUMBNAIL_SIGNED_URL_EXPIRES_SEC = 60;
+export const THUMBNAIL_MAX_SIDE = 384;
+export const THUMBNAIL_QUALITY = 78;
+export const THUMBNAIL_CONTENT_TYPE = "image/jpeg";
+
+export function defaultThumbnailObjectPath(userId: string, jobId: string): string {
+  return `${userId}/${jobId}/thumb.jpg`;
+}
+
+export function absolutizeSignedUrl(signedUrl: string): string {
+  if (signedUrl.startsWith("http://") || signedUrl.startsWith("https://")) {
+    return signedUrl;
+  }
+
+  const supabaseUrl = requireEnv("SUPABASE_URL").replace(/\/+$/, "");
+  if (signedUrl.startsWith("/storage/v1/")) return `${supabaseUrl}${signedUrl}`;
+  if (signedUrl.startsWith("/object/")) return `${supabaseUrl}/storage/v1${signedUrl}`;
+  if (signedUrl.startsWith("/")) return `${supabaseUrl}${signedUrl}`;
+  return `${supabaseUrl}/${signedUrl}`;
+}
+
+export async function createTransformedThumbnailUrl(resultObjectPath: string): Promise<string> {
+  const { data: signed, error: signedError } = await supabaseAdmin.storage
+    .from(RESULT_BUCKET)
+    .createSignedUrl(resultObjectPath, THUMBNAIL_SIGNED_URL_EXPIRES_SEC, {
+      transform: {
+        width: THUMBNAIL_MAX_SIDE,
+        height: THUMBNAIL_MAX_SIDE,
+        resize: "cover",
+      },
+    });
+
+  if (signedError || !signed?.signedUrl) {
+    throw new Error(`createSignedUrl failed: ${signedError?.message ?? "unknown"}`);
+  }
+
+  const baseURL = absolutizeSignedUrl(signed.signedUrl);
+  const separator = baseURL.includes("?") ? "&" : "?";
+  return `${baseURL}${separator}format=jpeg&quality=${THUMBNAIL_QUALITY}`;
+}
+
+export async function buildJpegThumbnailBytesFromResult(resultObjectPath: string): Promise<Uint8Array> {
+  const thumbnailURL = await createTransformedThumbnailUrl(resultObjectPath);
+
+  let response: Response;
+  try {
+    response = await fetch(thumbnailURL);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "thumbnail fetch failed";
+    throw new Error(message);
+  }
+
+  if (!response.ok) {
+    throw new Error(`thumbnail fetch status=${response.status}`);
+  }
+
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+export async function uploadJpegThumbnail(thumbnailObjectPath: string, bytes: Uint8Array): Promise<void> {
+  const { error } = await supabaseAdmin.storage
+    .from(THUMBNAIL_BUCKET)
+    .upload(thumbnailObjectPath, bytes, {
+      contentType: THUMBNAIL_CONTENT_TYPE,
+      upsert: true,
+    });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+
+export async function updateThumbnailPath(jobId: string, thumbnailObjectPath: string): Promise<void> {
+  const { error } = await supabaseAdmin
+    .from("nail_generation_jobs")
+    .update({
+      result_thumbnail_object_path: thumbnailObjectPath,
+    })
+    .eq("id", jobId)
+    .eq("status", "completed");
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}

--- a/supabase/functions/nail-gen-list/index.ts
+++ b/supabase/functions/nail-gen-list/index.ts
@@ -12,6 +12,9 @@ import { requireEnv } from "../_shared/env.ts";
 const RESULT_BUCKET = "nail-results-private";
 const THUMBNAIL_BUCKET = "nail-results-thumb-public";
 const RESULT_URL_EXPIRES_SEC = 10 * 60;
+const THUMBNAIL_FALLBACK_URL_EXPIRES_SEC = 60;
+const THUMBNAIL_FALLBACK_MAX_SIDE = 384;
+const THUMBNAIL_FALLBACK_QUALITY = 78;
 
 type CursorPayload = {
   created_at: string;
@@ -32,6 +35,10 @@ type NailGenerationRow = {
 type NailGenerationLikeRow = {
   job_id: string;
 };
+
+function listLog(requestId: string, message: string): void {
+  console.log(`[TODAYSNAIL][${requestId}][NAIL_GEN_LIST] ${message}`);
+}
 
 function isUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -81,7 +88,7 @@ function decodeCursor(raw: string | null): CursorPayload | null {
   }
 
   return {
-    created_at: createdAt,
+    created_at: new Date(createdAt).toISOString(),
     id: id.toLowerCase(),
   };
 }
@@ -111,6 +118,34 @@ function publicObjectUrl(bucket: string, objectPath: string): string {
   return `${supabaseUrl}/storage/v1/object/public/${bucket}/${encodedPath}`;
 }
 
+async function createResultImageUrl(objectPath: string): Promise<string> {
+  const { data: signed, error: signedError } = await supabaseAdmin.storage
+    .from(RESULT_BUCKET)
+    .createSignedUrl(objectPath, RESULT_URL_EXPIRES_SEC);
+  if (signedError || !signed?.signedUrl) {
+    throw new Error(`createSignedUrl failed: ${signedError?.message ?? "unknown"}`);
+  }
+  return absolutizeSignedUrl(signed.signedUrl);
+}
+
+async function createTransformedThumbnailUrl(objectPath: string): Promise<string> {
+  const { data: signed, error: signedError } = await supabaseAdmin.storage
+    .from(RESULT_BUCKET)
+    .createSignedUrl(objectPath, THUMBNAIL_FALLBACK_URL_EXPIRES_SEC, {
+      transform: {
+        width: THUMBNAIL_FALLBACK_MAX_SIDE,
+        height: THUMBNAIL_FALLBACK_MAX_SIDE,
+        resize: "cover",
+      },
+    });
+  if (signedError || !signed?.signedUrl) {
+    throw new Error(`createSignedUrl failed: ${signedError?.message ?? "unknown"}`);
+  }
+  const baseURL = absolutizeSignedUrl(signed.signedUrl);
+  const separator = baseURL.includes("?") ? "&" : "?";
+  return `${baseURL}${separator}format=jpeg&quality=${THUMBNAIL_FALLBACK_QUALITY}`;
+}
+
 async function requireUserId(req: Request): Promise<string> {
   const token = getBearerToken(req);
   if (!token) throw new Error("missing bearer token");
@@ -131,24 +166,30 @@ serve(async (req) => {
   if (req.method !== "GET") return errorResponse(405, "Method not allowed");
 
   try {
+    const requestId = crypto.randomUUID();
     const userId = await requireUserId(req);
     const url = new URL(req.url);
     const limit = parseLimit(url.searchParams.get("limit"));
     const likedOnly = parseLikedOnly(url.searchParams.get("liked_only"));
     const cursor = decodeCursor(url.searchParams.get("cursor"));
-    const fetchLimit = Math.min(200, limit + 40);
 
+    const likedLookupStartedAt = performance.now();
     const { data: likeRows, error: likeError } = await supabaseAdmin
       .from("nail_generation_likes")
       .select("job_id")
       .eq("user_id", userId);
     if (likeError) return errorResponse(500, `liked lookup failed: ${likeError.message}`);
+    const likedLookupMs = Math.round(performance.now() - likedLookupStartedAt);
 
     const likedJobIDs = new Set(
       ((likeRows ?? []) as NailGenerationLikeRow[])
         .map((row) => row.job_id.toLowerCase()),
     );
     if (likedOnly && likedJobIDs.size === 0) {
+      listLog(
+        requestId,
+        `liked_lookup_ms=${likedLookupMs} jobs_query_ms=0 signed_url_ms=0 thumbnail_missing_count=0 thumbnail_fallback_count=0 items_count=0 cursor_applied=${cursor ? "true" : "false"} liked_only=true empty_like_set=true`,
+      );
       return jsonResponse(200, { items: [], next_cursor: null });
     }
 
@@ -162,30 +203,34 @@ serve(async (req) => {
       .is("deleted_at", null)
       .order("created_at", { ascending: false })
       .order("id", { ascending: false })
-      .limit(fetchLimit);
+      .limit(limit);
 
     if (likedOnly) {
       query = query.in("id", Array.from(likedJobIDs));
     }
+    if (cursor) {
+      query = query.or(
+        `created_at.lt.${cursor.created_at},and(created_at.eq.${cursor.created_at},id.lt.${cursor.id})`,
+      );
+    }
 
+    const jobsQueryStartedAt = performance.now();
     const { data, error } = await query;
     if (error) return errorResponse(500, `job list lookup failed: ${error.message}`);
+    const jobsQueryMs = Math.round(performance.now() - jobsQueryStartedAt);
 
-    const sourceRows = (data ?? []) as NailGenerationRow[];
-    const filteredRows = sourceRows.filter((row) => {
-      if (!cursor) return true;
-
-      const cmpTime = row.created_at.localeCompare(cursor.created_at);
-      if (cmpTime < 0) return true;
-      if (cmpTime > 0) return false;
-      return row.id.toLowerCase() < cursor.id;
-    });
-    const pageRows = filteredRows.slice(0, limit);
+    const pageRows = (data ?? []) as NailGenerationRow[];
+    let thumbnailMissingCount = 0;
+    let thumbnailFallbackCount = 0;
+    const signedUrlStartedAt = performance.now();
 
     const items = await Promise.all(pageRows.map(async (row) => {
-      const thumbnailImageUrl = row.result_thumbnail_object_path
+      let thumbnailImageUrl = row.result_thumbnail_object_path
         ? publicObjectUrl(THUMBNAIL_BUCKET, row.result_thumbnail_object_path)
         : null;
+      if (!thumbnailImageUrl) {
+        thumbnailMissingCount += 1;
+      }
 
       if (!row.result_object_path) {
         return {
@@ -201,17 +246,23 @@ serve(async (req) => {
         };
       }
 
-      const { data: signed, error: signedError } = await supabaseAdmin.storage
-        .from(RESULT_BUCKET)
-        .createSignedUrl(row.result_object_path, RESULT_URL_EXPIRES_SEC);
-      if (signedError || !signed?.signedUrl) {
-        throw new Error(`createSignedUrl failed: ${signedError?.message ?? "unknown"}`);
+      const resultImageUrlPromise = createResultImageUrl(row.result_object_path);
+      let thumbnailImageUrlPromise: Promise<string | null>;
+      if (thumbnailImageUrl) {
+        thumbnailImageUrlPromise = Promise.resolve(thumbnailImageUrl);
+      } else {
+        thumbnailFallbackCount += 1;
+        thumbnailImageUrlPromise = createTransformedThumbnailUrl(row.result_object_path);
       }
+      const [resultImageUrl, resolvedThumbnailImageUrl] = await Promise.all([
+        resultImageUrlPromise,
+        thumbnailImageUrlPromise,
+      ]);
 
       return {
         job_id: row.id,
-        result_image_url: absolutizeSignedUrl(signed.signedUrl),
-        thumbnail_image_url: thumbnailImageUrl ?? absolutizeSignedUrl(signed.signedUrl),
+        result_image_url: resultImageUrl,
+        thumbnail_image_url: resolvedThumbnailImageUrl,
         shape: row.shape,
         extension_mode: row.extension_mode,
         created_at: row.created_at,
@@ -220,6 +271,7 @@ serve(async (req) => {
         is_liked: likedJobIDs.has(row.id.toLowerCase()),
       };
     }));
+    const signedUrlMs = Math.round(performance.now() - signedUrlStartedAt);
 
     const nextCursor = pageRows.length === limit
       ? (() => {
@@ -230,6 +282,11 @@ serve(async (req) => {
         });
       })()
       : null;
+
+    listLog(
+      requestId,
+      `liked_lookup_ms=${likedLookupMs} jobs_query_ms=${jobsQueryMs} signed_url_ms=${signedUrlMs} thumbnail_missing_count=${thumbnailMissingCount} thumbnail_fallback_count=${thumbnailFallbackCount} items_count=${items.length} cursor_applied=${cursor ? "true" : "false"} liked_only=${likedOnly ? "true" : "false"}`,
+    );
 
     return jsonResponse(200, {
       items,

--- a/supabase/functions/nail-gen-worker/index.ts
+++ b/supabase/functions/nail-gen-worker/index.ts
@@ -8,19 +8,23 @@ import {
   type AIGenerationPushEventType,
   type APNSPushToken,
 } from "../_shared/apns.ts";
+import {
+  buildJpegThumbnailBytesFromResult,
+  defaultThumbnailObjectPath,
+  RESULT_BUCKET,
+  THUMBNAIL_BUCKET,
+  THUMBNAIL_CONTENT_TYPE,
+  updateThumbnailPath,
+  uploadJpegThumbnail,
+} from "../_shared/nail-result-thumbnails.ts";
 
 const INPUT_BUCKET = "nail-inputs-private";
-const RESULT_BUCKET = "nail-results-private";
-const THUMBNAIL_BUCKET = "nail-results-thumb-public";
 const OPENAI_IMAGES_EDITS_URL = "https://api.openai.com/v1/images/edits";
 const WORKER_SECRET = requireEnv("NAIL_GEN_WORKER_SECRET");
 const OPENAI_API_KEY = requireEnv("OPENAI_API_KEY");
 const SUPABASE_URL = requireEnv("SUPABASE_URL").replace(/\/+$/, "");
 const MAX_BATCH = 3;
 const MAX_OPENAI_ATTEMPTS = 2;
-const THUMBNAIL_SIGNED_URL_EXPIRES_SEC = 60;
-const THUMBNAIL_MAX_SIDE = 384;
-const THUMBNAIL_QUALITY = 78;
 const SELF_TRIGGER_TIMEOUT_MS = 1500;
 const IMAGE_MODEL: ImageModel = "gpt-image-1.5";
 type ImageModel = "gpt-image-1.5";
@@ -397,59 +401,6 @@ async function triggerWorkerDrainPass(jobIdForLog: string): Promise<void> {
   }
 }
 
-async function buildThumbnailFromResult(
-  resultObjectPath: string,
-): Promise<{ bytes: Uint8Array; contentType: string }> {
-  const { data: signed, error: signedError } = await supabaseAdmin.storage
-    .from(RESULT_BUCKET)
-    .createSignedUrl(resultObjectPath, THUMBNAIL_SIGNED_URL_EXPIRES_SEC, {
-      transform: {
-        width: THUMBNAIL_MAX_SIDE,
-        height: THUMBNAIL_MAX_SIDE,
-        resize: "cover",
-      },
-    });
-
-  if (signedError || !signed?.signedUrl) {
-    throw new WorkerError(
-      "THUMBNAIL_SIGNED_URL_FAILED",
-      `createSignedUrl failed: ${signedError?.message ?? "unknown"}`,
-      true,
-    );
-  }
-
-  const baseURL = absolutizeSignedUrl(signed.signedUrl);
-  const separator = baseURL.includes("?") ? "&" : "?";
-  const thumbnailURL = `${baseURL}${separator}format=jpeg&quality=${THUMBNAIL_QUALITY}`;
-
-  let response: Response;
-  try {
-    response = await fetch(thumbnailURL);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : "thumbnail fetch failed";
-    throw new WorkerError("THUMBNAIL_FETCH_FAILED", message, true);
-  }
-
-  if (!response.ok) {
-    throw new WorkerError(
-      "THUMBNAIL_FETCH_FAILED",
-      `thumbnail fetch status=${response.status}`,
-      true,
-      response.status,
-    );
-  }
-
-  const contentType = response.headers.get("content-type")
-    ?.split(";")[0]
-    ?.trim()
-    ?.toLowerCase() || "image/jpeg";
-
-  return {
-    bytes: new Uint8Array(await response.arrayBuffer()),
-    contentType,
-  };
-}
-
 async function claimJob(job: JobRow): Promise<JobRow | null> {
   const { data, error } = await supabaseAdmin
     .from("nail_generation_jobs")
@@ -493,20 +444,6 @@ async function completeJob(
 
   if (error) {
     throw new WorkerError("JOB_COMPLETE_UPDATE_FAILED", error.message, false);
-  }
-}
-
-async function updateJobThumbnailPath(jobId: string, thumbnailObjectPath: string): Promise<void> {
-  const { error } = await supabaseAdmin
-    .from("nail_generation_jobs")
-    .update({
-      result_thumbnail_object_path: thumbnailObjectPath,
-    })
-    .eq("id", jobId)
-    .eq("status", "completed");
-
-  if (error) {
-    throw new WorkerError("THUMBNAIL_UPDATE_FAILED", error.message, true);
   }
 }
 
@@ -589,20 +526,11 @@ async function generateAndAttachThumbnail(
 ): Promise<void> {
   const thumbnailStartedAt = performance.now();
   try {
-    const thumbnail = await buildThumbnailFromResult(resultObjectPath);
-    const { error: thumbnailUploadError } = await supabaseAdmin.storage
-      .from(THUMBNAIL_BUCKET)
-      .upload(thumbnailObjectPath, thumbnail.bytes, {
-        contentType: thumbnail.contentType || "image/jpeg",
-        upsert: true,
-      });
-    if (thumbnailUploadError) {
-      throw new WorkerError("THUMBNAIL_UPLOAD_FAILED", thumbnailUploadError.message, true);
-    }
-
-    await updateJobThumbnailPath(job.id, thumbnailObjectPath);
+    const thumbnailBytes = await buildJpegThumbnailBytesFromResult(resultObjectPath);
+    await uploadJpegThumbnail(thumbnailObjectPath, thumbnailBytes);
+    await updateThumbnailPath(job.id, thumbnailObjectPath);
     const thumbnailMs = performance.now() - thumbnailStartedAt;
-    jobLog(job.id, `thumbnail_ready thumbnail_ms=${clampMs(thumbnailMs)}`);
+    jobLog(job.id, `thumbnail_ready thumbnail_ms=${clampMs(thumbnailMs)} content_type=${THUMBNAIL_CONTENT_TYPE}`);
   } catch (e) {
     const message = e instanceof Error ? truncate(e.message, 180) : "thumbnail unknown error";
     jobLog(job.id, `thumbnail_skipped reason=${message}`);
@@ -650,7 +578,7 @@ serve(async (req) => {
       const jobStartedAt = performance.now();
       const openaiResult = await callOpenAIWithRetry(claimed);
       const resultObjectPath = `${claimed.user_id}/${claimed.id}/result.png`;
-      const thumbnailObjectPath = `${claimed.user_id}/${claimed.id}/thumb.jpg`;
+      const thumbnailObjectPath = defaultThumbnailObjectPath(claimed.user_id, claimed.id);
       claimed.model = openaiResult.model;
 
       const uploadStartedAt = performance.now();


### PR DESCRIPTION
## Summary
- unify generated thumbnails to JPEG in `nail-gen-worker`
- keep the current safe `nail-gen-list` fallback and logging behavior in-repo
- add a one-off backfill script for missing or non-JPEG thumbnails

## Validation
- `deno check supabase/functions/nail-gen-worker/index.ts supabase/functions/nail-gen-list/index.ts scripts/backfill-nail-result-thumbnails.ts`
- `git diff --check`
- live deploy completed before commit for `nail-gen-worker` and `nail-gen-list`
- live backfill completed in two batches: `20` then remaining `21`
- representative user first page changed from `3/20` stored thumbnails to `20/20` JPEG thumbnails
- global remaining target count after backfill: `0`

## Contract safety
- `nail-gen-list` response keys/types/nullability are unchanged
- `result_image_url` is still returned
- `thumbnail_image_url` remains available with the current fallback path preserved

Closes #12
