### PR TITLE
fix(thumbnails): 생성 결과 보기 탭 썸네일 스펙 경량화와 JPEG 백필

### DIFF
--- a/scripts/backfill-nail-result-thumbnails.ts
+++ b/scripts/backfill-nail-result-thumbnails.ts
@@ -3,6 +3,7 @@ import pg from "npm:pg";
 import {
   buildJpegThumbnailBytesFromResult,
   defaultThumbnailObjectPath,
+  THUMBNAIL_BACKFILL_MAX_BYTES,
   THUMBNAIL_BUCKET,
   THUMBNAIL_CONTENT_TYPE,
   updateThumbnailPath,
@@ -21,11 +22,20 @@ type JobRow = {
 type StorageObjectRow = {
   name: string;
   mimetype: string | null;
+  size_bytes: number | null;
 };
 
+function requireFirstEnv(...keys: string[]): string {
+  for (const key of keys) {
+    const value = Deno.env.get(key)?.trim();
+    if (value) return value;
+  }
+  throw new Error(`Missing required environment variable. Tried: ${keys.join(", ")}`);
+}
+
 const supabaseUrl = requireEnv("SUPABASE_URL");
-const dbUrl = requireEnv("SUPABASE_DB_URL");
-const serviceRoleKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+const dbUrl = requireFirstEnv("SUPABASE_DB_URL", "SUPABASE_DB_URL_SHARED_STAGING");
+const serviceRoleKey = requireFirstEnv("SUPABASE_SERVICE_ROLE_KEY");
 const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
   auth: { persistSession: false, autoRefreshToken: false },
 });
@@ -129,7 +139,8 @@ async function loadThumbnailMetadata(paths: string[]): Promise<Map<string, Stora
     `
       select
         name,
-        metadata->>'mimetype' as mimetype
+        metadata->>'mimetype' as mimetype,
+        nullif(metadata->>'size', '')::int as size_bytes
       from storage.objects
       where bucket_id = $1
         and name = any($2::text[])
@@ -143,7 +154,8 @@ async function loadThumbnailMetadata(paths: string[]): Promise<Map<string, Stora
 function needsRegeneration(job: JobRow, objectRow: StorageObjectRow | undefined): boolean {
   if (!job.result_thumbnail_object_path) return true;
   if (!objectRow) return true;
-  return objectRow.mimetype !== THUMBNAIL_CONTENT_TYPE;
+  if (objectRow.mimetype !== THUMBNAIL_CONTENT_TYPE) return true;
+  return (objectRow.size_bytes ?? 0) > THUMBNAIL_BACKFILL_MAX_BYTES;
 }
 
 async function regenerateThumbnail(job: JobRow): Promise<void> {
@@ -193,6 +205,7 @@ try {
     regenerated_count: regeneratedCount,
     skipped_count: skippedCount,
     failed_count: failedCount,
+    max_allowed_thumbnail_bytes: THUMBNAIL_BACKFILL_MAX_BYTES,
     last_processed_job_id: lastProcessedJobId,
     dry_run: options.dryRun,
   }, null, 2));

--- a/supabase/functions/_shared/nail-result-thumbnails.ts
+++ b/supabase/functions/_shared/nail-result-thumbnails.ts
@@ -4,9 +4,10 @@ import { supabaseAdmin } from "./supabase.ts";
 export const RESULT_BUCKET = "nail-results-private";
 export const THUMBNAIL_BUCKET = "nail-results-thumb-public";
 export const THUMBNAIL_SIGNED_URL_EXPIRES_SEC = 60;
-export const THUMBNAIL_MAX_SIDE = 384;
-export const THUMBNAIL_QUALITY = 78;
+export const THUMBNAIL_MAX_SIDE = 320;
+export const THUMBNAIL_QUALITY = 72;
 export const THUMBNAIL_CONTENT_TYPE = "image/jpeg";
+export const THUMBNAIL_BACKFILL_MAX_BYTES = 280 * 1024;
 
 export function defaultThumbnailObjectPath(userId: string, jobId: string): string {
   return `${userId}/${jobId}/thumb.jpg`;

--- a/supabase/functions/nail-gen-list/index.ts
+++ b/supabase/functions/nail-gen-list/index.ts
@@ -13,8 +13,8 @@ const RESULT_BUCKET = "nail-results-private";
 const THUMBNAIL_BUCKET = "nail-results-thumb-public";
 const RESULT_URL_EXPIRES_SEC = 10 * 60;
 const THUMBNAIL_FALLBACK_URL_EXPIRES_SEC = 60;
-const THUMBNAIL_FALLBACK_MAX_SIDE = 384;
-const THUMBNAIL_FALLBACK_QUALITY = 78;
+const THUMBNAIL_FALLBACK_MAX_SIDE = 320;
+const THUMBNAIL_FALLBACK_QUALITY = 72;
 
 type CursorPayload = {
   created_at: string;


### PR DESCRIPTION
Closes #14

## Summary
- 결과 탭 썸네일 기본 스펙을 320x320 JPEG quality 72로 경량화했습니다.
- `nail-gen-list` fallback 썸네일도 동일 스펙을 사용하도록 맞췄습니다.
- backfill 스크립트에 대용량 JPEG 재생성 기준을 추가했습니다.

## Live validation
- representative user first page avg thumbnail size: 193404.4 -> 139936.0 bytes
- representative user first page max thumbnail size: 296226 -> 213098 bytes
- final backfill target count (missing / non-JPEG / oversized > 280KB): 0

## Notes
- response keys/types/nullability are unchanged
- original result image format is unchanged
