### PR TITLE
chore: Ignore local Codex artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ supabase/.branches/
 .env
 .env.local
 !.env.example
+.codex-baselines/
+.codex-postdeploy/


### PR DESCRIPTION
## Summary
- add local Codex artifact directories to `.gitignore`
- keep the change scoped to repository hygiene only

## Verification
- `git status --short`
- `git status --short --ignored .codex-baselines .codex-postdeploy`

Closes #24
