### PR TITLE
refactor: Harden function validation scripts

### DIFF
--- a/scripts/deploy-functions.sh
+++ b/scripts/deploy-functions.sh
@@ -2,24 +2,19 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-FUNCTIONS_DIR="$ROOT_DIR/supabase/functions"
-PROJECT_REF="${1:-${SUPABASE_PROJECT_REF:-twahqxjhyocyqrmtjbdf}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/functions-common.sh
+source "$SCRIPT_DIR/lib/functions-common.sh"
 
-if ! command -v supabase >/dev/null 2>&1; then
-  echo "ERROR: supabase CLI is not installed."
-  exit 1
-fi
+PROJECT_REF="$(resolve_project_ref "${1:-}")"
 
-if [[ ! -d "$FUNCTIONS_DIR" ]]; then
-  echo "ERROR: functions directory not found: $FUNCTIONS_DIR"
-  exit 1
-fi
+require_command "supabase"
 
 FUNCTIONS=()
-while IFS= read -r file; do
-  FUNCTIONS+=("$(basename "$(dirname "$file")")")
-done < <(find "$FUNCTIONS_DIR" -mindepth 2 -maxdepth 2 -name "index.ts" | sort)
+while IFS= read -r func_name; do
+  [[ -n "$func_name" ]] || continue
+  FUNCTIONS+=("$func_name")
+done < <(list_local_function_names)
 
 if [[ ${#FUNCTIONS[@]} -eq 0 ]]; then
   echo "No local edge functions found."

--- a/scripts/functions-check-auth-config.sh
+++ b/scripts/functions-check-auth-config.sh
@@ -2,24 +2,14 @@
 
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-FUNCTIONS_DIR="$ROOT_DIR/supabase/functions"
-PROJECT_REF="${1:-${SUPABASE_PROJECT_REF:-twahqxjhyocyqrmtjbdf}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/functions-common.sh
+source "$SCRIPT_DIR/lib/functions-common.sh"
 
-if ! command -v supabase >/dev/null 2>&1; then
-  echo "ERROR: supabase CLI is not installed."
-  exit 1
-fi
+PROJECT_REF="$(resolve_project_ref "${1:-}")"
 
-if ! command -v jq >/dev/null 2>&1; then
-  echo "ERROR: jq is not installed."
-  exit 1
-fi
-
-if [[ ! -d "$FUNCTIONS_DIR" ]]; then
-  echo "ERROR: functions directory not found: $FUNCTIONS_DIR"
-  exit 1
-fi
+require_command "jq"
+require_command "supabase"
 
 expected_mode_for() {
   case "$1" in
@@ -76,10 +66,10 @@ required_secrets_for_mode() {
 }
 
 LOCAL_FUNCTIONS=()
-while IFS= read -r file; do
-  func_name="$(basename "$(dirname "$file")")"
+while IFS= read -r func_name; do
+  [[ -n "$func_name" ]] || continue
   LOCAL_FUNCTIONS+=("$func_name")
-done < <(find "$FUNCTIONS_DIR" -mindepth 2 -maxdepth 2 -name "index.ts" | sort)
+done < <(list_local_function_names)
 
 if [[ ${#LOCAL_FUNCTIONS[@]} -eq 0 ]]; then
   echo "No local edge functions found."

--- a/scripts/functions-check-deployed.sh
+++ b/scripts/functions-check-deployed.sh
@@ -1,50 +1,37 @@
 #!/usr/bin/env bash
 
-set -uo pipefail
+set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-FUNCTIONS_DIR="$ROOT_DIR/supabase/functions"
-PROJECT_REF="${1:-${SUPABASE_PROJECT_REF:-twahqxjhyocyqrmtjbdf}}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/functions-common.sh
+source "$SCRIPT_DIR/lib/functions-common.sh"
 
-if ! command -v supabase >/dev/null 2>&1; then
-  echo "ERROR: supabase CLI is not installed."
-  exit 1
-fi
+PROJECT_REF="$(resolve_project_ref "${1:-}")"
 
-if [[ ! -d "$FUNCTIONS_DIR" ]]; then
-  echo "ERROR: functions directory not found: $FUNCTIONS_DIR"
-  exit 1
-fi
+require_command "jq"
+require_command "supabase"
 
 LOCAL_FUNCTIONS=()
-while IFS= read -r file; do
-  func_name="$(basename "$(dirname "$file")")"
+while IFS= read -r func_name; do
+  [[ -n "$func_name" ]] || continue
   LOCAL_FUNCTIONS+=("$func_name")
-done < <(find "$FUNCTIONS_DIR" -mindepth 2 -maxdepth 2 -name "index.ts" | sort)
+done < <(list_local_function_names)
 
 if [[ ${#LOCAL_FUNCTIONS[@]} -eq 0 ]]; then
   echo "No local edge functions found."
   exit 1
 fi
 
-LIST_OUTPUT="$(supabase functions list --project-ref "$PROJECT_REF")"
-if [[ $? -ne 0 ]]; then
+if ! REMOTE_JSON="$(supabase functions list -o json --project-ref "$PROJECT_REF")"; then
   echo "ERROR: failed to list remote functions for project: $PROJECT_REF"
   exit 1
 fi
 
 REMOTE_FUNCTIONS=()
-while IFS= read -r line; do
-  name="$(echo "$line" | awk -F'|' '{gsub(/^ +| +$/, "", $3); print $3}')"
-  if [[ -n "$name" && "$name" != "SLUG" ]]; then
-    REMOTE_FUNCTIONS+=("$name")
-  fi
-done < <(echo "$LIST_OUTPUT" | awk -F'|' '/\|/ && $0 !~ /---/')
-
-if [[ ${#REMOTE_FUNCTIONS[@]} -eq 0 ]]; then
-  echo "ERROR: no remote functions found on project: $PROJECT_REF"
-  exit 1
-fi
+while IFS= read -r remote_name; do
+  [[ -n "$remote_name" ]] || continue
+  REMOTE_FUNCTIONS+=("$remote_name")
+done < <(echo "$REMOTE_JSON" | jq -r '.[].name' | sort -u)
 
 MISSING=()
 for func_name in "${LOCAL_FUNCTIONS[@]}"; do

--- a/scripts/lib/functions-common.sh
+++ b/scripts/lib/functions-common.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+COMMON_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$COMMON_LIB_DIR/../.." && pwd)"
+FUNCTIONS_DIR="$ROOT_DIR/supabase/functions"
+DEFAULT_SUPABASE_PROJECT_REF="twahqxjhyocyqrmtjbdf"
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "ERROR: required command is not installed: $command_name"
+    exit 1
+  fi
+}
+
+resolve_project_ref() {
+  local cli_arg="${1:-}"
+
+  if [[ -n "$cli_arg" ]]; then
+    printf '%s\n' "$cli_arg"
+    return
+  fi
+
+  if [[ -n "${SUPABASE_PROJECT_REF:-}" ]]; then
+    printf '%s\n' "$SUPABASE_PROJECT_REF"
+    return
+  fi
+
+  printf '%s\n' "$DEFAULT_SUPABASE_PROJECT_REF"
+}
+
+ensure_functions_dir() {
+  if [[ ! -d "$FUNCTIONS_DIR" ]]; then
+    echo "ERROR: functions directory not found: $FUNCTIONS_DIR"
+    exit 1
+  fi
+}
+
+list_local_function_names() {
+  ensure_functions_dir
+
+  find "$FUNCTIONS_DIR" -mindepth 2 -maxdepth 2 -name "index.ts" \
+    | while IFS= read -r file; do
+        basename "$(dirname "$file")"
+      done \
+    | sort -u
+}


### PR DESCRIPTION
## Summary
- extract shared function-script helpers for project-ref resolution and local discovery
- switch deployed-function validation to `supabase functions list -o json`
- keep existing positional-argument overrides and validation intent intact

## Verification
- `bash -n scripts/deploy-functions.sh`
- `bash -n scripts/functions-check-deployed.sh`
- `bash -n scripts/functions-check-auth-config.sh`
- `bash -n scripts/lib/functions-common.sh`
- `bash scripts/check-migration-names.sh`
- mock `supabase` success and missing-function validation runs

Closes #28
