### PR TITLE
refactor: Deduplicate shared deployment workflow steps

### DIFF
--- a/.github/workflows/apply-shared-staging.yml
+++ b/.github/workflows/apply-shared-staging.yml
@@ -8,7 +8,9 @@ on:
       - 'migrations/**'
       - 'supabase/functions/**'
       - 'scripts/check-migration-names.sh'
+      - 'scripts/prepare-shared-deploy.sh'
       - 'scripts/deploy-functions.sh'
+      - 'scripts/deploy-and-validate-functions.sh'
       - 'scripts/functions-check-deployed.sh'
       - 'scripts/functions-check-auth-config.sh'
       - '.github/workflows/apply-shared-staging.yml'
@@ -21,21 +23,14 @@ concurrency:
 jobs:
   apply-staging:
     runs-on: ubuntu-latest
-    env:
-      SUPABASE_PROJECT_REF: twahqxjhyocyqrmtjbdf
     steps:
       - uses: actions/checkout@v4
-
-      - name: Validate migration filenames
-        run: bash scripts/check-migration-names.sh
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
 
-      - name: Prepare supabase migration directory
-        run: |
-          mkdir -p supabase/migrations
-          rsync -a --delete migrations/ supabase/migrations/
+      - name: Prepare shared deploy inputs
+        run: bash scripts/prepare-shared-deploy.sh
 
       - name: Apply to shared-staging
         env:
@@ -62,33 +57,11 @@ jobs:
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
           echo "function_changes=$changed"
 
-      - name: Validate Supabase access token
+      - name: Deploy and validate edge functions
         if: steps.function_changes.outputs.changed == 'true'
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-        run: |
-          if [[ -z "${SUPABASE_ACCESS_TOKEN:-}" ]]; then
-            echo "::error::SUPABASE_ACCESS_TOKEN secret is required when deploying functions."
-            exit 1
-          fi
-
-      - name: Deploy edge functions
-        if: steps.function_changes.outputs.changed == 'true'
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-        run: bash scripts/deploy-functions.sh "$SUPABASE_PROJECT_REF"
-
-      - name: Validate deployed functions
-        if: steps.function_changes.outputs.changed == 'true'
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-        run: bash scripts/functions-check-deployed.sh "$SUPABASE_PROJECT_REF"
-
-      - name: Validate auth config
-        if: steps.function_changes.outputs.changed == 'true'
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-        run: bash scripts/functions-check-auth-config.sh "$SUPABASE_PROJECT_REF"
+        run: bash scripts/deploy-and-validate-functions.sh
 
       - name: Skip function deploy (no function changes)
         if: steps.function_changes.outputs.changed != 'true'

--- a/.github/workflows/promote-shared-prod.yml
+++ b/.github/workflows/promote-shared-prod.yml
@@ -11,38 +11,21 @@ jobs:
   promote-prod:
     runs-on: ubuntu-latest
     environment: shared-prod
-    env:
-      SUPABASE_PROJECT_REF: twahqxjhyocyqrmtjbdf
     steps:
       - uses: actions/checkout@v4
-
-      - name: Validate migration filenames
-        run: bash scripts/check-migration-names.sh
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
 
-      - name: Prepare supabase migration directory
-        run: |
-          mkdir -p supabase/migrations
-          rsync -a --delete migrations/ supabase/migrations/
+      - name: Prepare shared deploy inputs
+        run: bash scripts/prepare-shared-deploy.sh
 
       - name: Apply to shared-prod
         env:
           SUPABASE_DB_URL_SHARED_PROD: ${{ secrets.SUPABASE_DB_URL_SHARED_PROD }}
         run: supabase db push --db-url "$SUPABASE_DB_URL_SHARED_PROD"
 
-      - name: Deploy edge functions
+      - name: Deploy and validate edge functions
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-        run: bash scripts/deploy-functions.sh "$SUPABASE_PROJECT_REF"
-
-      - name: Validate deployed functions
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-        run: bash scripts/functions-check-deployed.sh "$SUPABASE_PROJECT_REF"
-
-      - name: Validate auth config
-        env:
-          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-        run: bash scripts/functions-check-auth-config.sh "$SUPABASE_PROJECT_REF"
+        run: bash scripts/deploy-and-validate-functions.sh

--- a/scripts/deploy-and-validate-functions.sh
+++ b/scripts/deploy-and-validate-functions.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_REF="${1:-${SUPABASE_PROJECT_REF:-twahqxjhyocyqrmtjbdf}}"
+
+if [[ -z "${SUPABASE_ACCESS_TOKEN:-}" ]]; then
+  echo "ERROR: SUPABASE_ACCESS_TOKEN secret is required when deploying functions."
+  exit 1
+fi
+
+bash "$SCRIPT_DIR/deploy-functions.sh" "$PROJECT_REF"
+bash "$SCRIPT_DIR/functions-check-deployed.sh" "$PROJECT_REF"
+bash "$SCRIPT_DIR/functions-check-auth-config.sh" "$PROJECT_REF"
+
+echo "[deploy-and-validate-functions] completed for project $PROJECT_REF"

--- a/scripts/prepare-shared-deploy.sh
+++ b/scripts/prepare-shared-deploy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+bash "$ROOT_DIR/scripts/check-migration-names.sh"
+
+mkdir -p "$ROOT_DIR/supabase/migrations"
+rsync -a --delete "$ROOT_DIR/migrations/" "$ROOT_DIR/supabase/migrations/"
+
+echo "[prepare-shared-deploy] prepared supabase/migrations from migrations/"


### PR DESCRIPTION
## Summary
- move shared migration-preparation logic into `scripts/prepare-shared-deploy.sh`
- move shared function deploy and validation flow into `scripts/deploy-and-validate-functions.sh`
- keep staging/prod triggers, DB secrets, and environment approval semantics unchanged

## Verification
- `bash -n scripts/prepare-shared-deploy.sh`
- `bash -n scripts/deploy-and-validate-functions.sh`
- `bash scripts/prepare-shared-deploy.sh`
- mock `supabase` run for `bash scripts/deploy-and-validate-functions.sh mock-project`
- `git diff --check`
- workflow trigger/secret/environment grep checks

Closes #30
