### PR TITLE
fix: nail-gen-worker auth 설정 드리프트 방지

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Example local commands:
 ```bash
 # repo root: shared-schema
 bash scripts/deploy-functions.sh
+bash scripts/deploy-single-function.sh nail-gen-worker
 bash scripts/functions-check-deployed.sh
 bash scripts/functions-check-auth-config.sh
 ```

--- a/scripts/deploy-functions.sh
+++ b/scripts/deploy-functions.sh
@@ -22,8 +22,14 @@ if [[ ${#FUNCTIONS[@]} -eq 0 ]]; then
 fi
 
 for func_name in "${FUNCTIONS[@]}"; do
-  echo "[deploy-functions] deploying: $func_name"
-  supabase functions deploy "$func_name" --project-ref "$PROJECT_REF" --no-verify-jwt
+  expected_verify_jwt="$(expected_verify_jwt_for_function "$func_name")"
+  deploy_args=()
+  if [[ "$expected_verify_jwt" == "false" ]]; then
+    deploy_args+=(--no-verify-jwt)
+  fi
+
+  echo "[deploy-functions] deploying: $func_name verify_jwt=$expected_verify_jwt"
+  supabase functions deploy "$func_name" --project-ref "$PROJECT_REF" "${deploy_args[@]}"
 done
 
 echo "[deploy-functions] completed. deployed=${#FUNCTIONS[@]} project=$PROJECT_REF"

--- a/scripts/deploy-single-function.sh
+++ b/scripts/deploy-single-function.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/functions-common.sh
+source "$SCRIPT_DIR/lib/functions-common.sh"
+
+PROJECT_REF="$(resolve_project_ref "${2:-}")"
+FUNCTION_NAME="${1:-}"
+
+require_command "supabase"
+
+if [[ -z "$FUNCTION_NAME" ]]; then
+  echo "Usage: bash scripts/deploy-single-function.sh <function-name> [project-ref]"
+  exit 1
+fi
+
+if [[ ! -f "$FUNCTIONS_DIR/$FUNCTION_NAME/index.ts" ]]; then
+  echo "ERROR: function not found: $FUNCTION_NAME"
+  exit 1
+fi
+
+MODE="$(expected_mode_for_function "$FUNCTION_NAME")"
+if [[ -z "$MODE" ]]; then
+  echo "ERROR: auth mode classification is missing for function: $FUNCTION_NAME"
+  exit 1
+fi
+
+EXPECTED_VERIFY_JWT="$(expected_verify_jwt_for_mode "$MODE")"
+DEPLOY_ARGS=()
+if [[ "$EXPECTED_VERIFY_JWT" == "false" ]]; then
+  DEPLOY_ARGS+=(--no-verify-jwt)
+fi
+
+echo "[deploy-single-function] deploying: $FUNCTION_NAME mode=$MODE verify_jwt=$EXPECTED_VERIFY_JWT"
+supabase functions deploy "$FUNCTION_NAME" --project-ref "$PROJECT_REF" "${DEPLOY_ARGS[@]}"
+bash "$SCRIPT_DIR/functions-check-auth-config.sh" "$PROJECT_REF"
+
+echo "[deploy-single-function] completed. function=$FUNCTION_NAME project=$PROJECT_REF"

--- a/scripts/functions-check-auth-config.sh
+++ b/scripts/functions-check-auth-config.sh
@@ -12,43 +12,11 @@ require_command "jq"
 require_command "supabase"
 
 expected_mode_for() {
-  case "$1" in
-    feed-detail|feed-like|feed-list|nail-gen-delete|nail-gen-like|nail-gen-list|nail-gen-refine-request|nail-gen-request|nail-gen-status|nail-gen-upload-url|owner-dashboard-summary|owner-notification-list|owner-notification-mark-all-read|owner-notification-mark-read|owner-payment-ledger-upsert|owner-quote-request-list|owner-quote-response-upsert|profile-style-insight|push-token-deactivate|push-token-upsert|quote-request-create|quote-request-list|quote-response-list|quote-response-select|region-boundary|regions-list|regions-tree|reservation-create|reservation-list|reservation-slots|shop-detail|shop-recommend|shop-search|users-delete|users-me)
-      echo "app_access_jwt"
-      ;;
-    auth-refresh|auth-logout)
-      echo "refresh_token"
-      ;;
-    auth-kakao)
-      echo "kakao_exchange"
-      ;;
-    auth-google)
-      echo "google_exchange"
-      ;;
-    auth-apple)
-      echo "apple_exchange"
-      ;;
-    public-app-config|public-onboarding-styles)
-      echo "public_config"
-      ;;
-    nail-gen-worker)
-      echo "worker_secret"
-      ;;
-    *)
-      echo ""
-      ;;
-  esac
+  expected_mode_for_function "$1"
 }
 
 expected_verify_jwt_for() {
-  case "$1" in
-    "")
-      echo ""
-      ;;
-    *)
-      echo "false"
-      ;;
-  esac
+  expected_verify_jwt_for_mode "$1"
 }
 
 required_secrets_for_mode() {

--- a/scripts/lib/functions-common.sh
+++ b/scripts/lib/functions-common.sh
@@ -46,3 +46,49 @@ list_local_function_names() {
       done \
     | sort -u
 }
+
+expected_mode_for_function() {
+  case "$1" in
+    feed-detail|feed-like|feed-list|nail-gen-delete|nail-gen-like|nail-gen-list|nail-gen-refine-request|nail-gen-request|nail-gen-status|nail-gen-upload-url|owner-dashboard-summary|owner-notification-list|owner-notification-mark-all-read|owner-notification-mark-read|owner-payment-ledger-upsert|owner-quote-request-list|owner-quote-response-upsert|profile-style-insight|push-token-deactivate|push-token-upsert|quote-request-create|quote-request-list|quote-response-list|quote-response-select|region-boundary|regions-list|regions-tree|reservation-create|reservation-list|reservation-slots|shop-detail|shop-recommend|shop-search|users-delete|users-me)
+      echo "app_access_jwt"
+      ;;
+    auth-refresh|auth-logout)
+      echo "refresh_token"
+      ;;
+    auth-kakao)
+      echo "kakao_exchange"
+      ;;
+    auth-google)
+      echo "google_exchange"
+      ;;
+    auth-apple)
+      echo "apple_exchange"
+      ;;
+    public-app-config|public-onboarding-styles)
+      echo "public_config"
+      ;;
+    nail-gen-worker)
+      echo "worker_secret"
+      ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
+expected_verify_jwt_for_mode() {
+  case "$1" in
+    "")
+      echo ""
+      ;;
+    *)
+      echo "false"
+      ;;
+  esac
+}
+
+expected_verify_jwt_for_function() {
+  local mode
+  mode="$(expected_mode_for_function "$1")"
+  expected_verify_jwt_for_mode "$mode"
+}


### PR DESCRIPTION
## 요약
- 함수 auth 분류와 `verify_jwt` 기대값을 공통 유틸로 통합했습니다.
- 단건 함수도 안전하게 재배포할 수 있도록 `scripts/deploy-single-function.sh`를 추가했습니다.
- `nail-gen-worker`를 staging에 `verify_jwt=false` 상태로 재배포했고 auth config 검증 통과를 확인했습니다.

## 검증
- `bash scripts/functions-check-auth-config.sh twahqxjhyocyqrmtjbdf`
- `bash scripts/deploy-single-function.sh nail-gen-worker twahqxjhyocyqrmtjbdf`

## 참고
- backlog drain 및 후속 end-to-end 확인은 별도 이슈로 분리했습니다: #33

Closes #32
Refs: #33
