### PR TITLE
fix: Supabase CLI 버전 고정

### DIFF
--- a/.github/workflows/apply-shared-staging.yml
+++ b/.github/workflows/apply-shared-staging.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
+        with:
+          version: latest
 
       - name: Prepare shared deploy inputs
         run: bash scripts/prepare-shared-deploy.sh

--- a/.github/workflows/promote-shared-prod.yml
+++ b/.github/workflows/promote-shared-prod.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
+        with:
+          version: latest
 
       - name: Prepare shared deploy inputs
         run: bash scripts/prepare-shared-deploy.sh


### PR DESCRIPTION
## Summary
- Pin Supabase CLI setup to `version: latest` in staging and prod deployment workflows.
- Keep the change workflow-only so runtime DB/function behavior is unchanged.

## Why
`Apply Shared Staging` now receives `SUPABASE_ACCESS_TOKEN`, but failed during function validation because `supabase/setup-cli@v1` installed the old default CLI `v2.20.3`. The validation scripts expect `supabase functions list -o json` output that can be parsed by `jq`.

## Validation
- `git diff --check`
- Confirmed failed run had `SUPABASE_ACCESS_TOKEN: ***`, so the secret is now available to Actions.
- Follow-up validation: rerun `Apply Shared Staging` after merge.

## Scope
In scope:
- `.github/workflows/apply-shared-staging.yml`
- `.github/workflows/promote-shared-prod.yml`

Out of scope:
- DB schema changes
- Edge Function runtime changes
- Production deployment execution

Closes #39
